### PR TITLE
strip unnecessary the exclamation marks

### DIFF
--- a/Classes/Watchdog.swift
+++ b/Classes/Watchdog.swift
@@ -56,13 +56,14 @@ import Foundation
                     weakSelf.startTime = 0
                     
                 default: ()
+
                 }
         }
         
-        CFRunLoopAddObserver(CFRunLoopGetMain(), observer!, kCFRunLoopCommonModes)
+        CFRunLoopAddObserver(CFRunLoopGetMain(), observer, kCFRunLoopCommonModes)
     }
     
     deinit {
-        CFRunLoopObserverInvalidate(observer!)
+        CFRunLoopObserverInvalidate(observer)
     }
 }


### PR DESCRIPTION
through the swift programming guide, when you know that the variable will never be nil when it has been initiated, maybe treat it as a normal variable is a better way, after all, you can see its type in the quick help window
