### PR TITLE
Add OSX to podspec

### DIFF
--- a/Watchdog.podspec
+++ b/Watchdog.podspec
@@ -13,12 +13,10 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/wojteklukaszuk/Watchdog.git", :tag => s.version }
   s.social_media_url = 'https://twitter.com/wojteklukaszuk'
 
-  s.platform     = :ios, '8.0'
+  s.ios.deployment_target = '8.0' 
+  s.osx.deployment_target = '10.9'
   s.requires_arc = true
 
   s.source_files = 'Classes/*.swift'
-  s.resource_bundles = {
-    'Watchdog' => ['Assets/*.png']
-  }
 
 end


### PR DESCRIPTION
added OSX, tested with a `sleep`into main queue 

and remove `resource_bundles` part, I have missing bundle error when I try to compil with that on OSX project, and I don't see any Asset folder with png file into this project
