### PR TITLE
Support tvos in Podspec

### DIFF
--- a/Watchdog.podspec
+++ b/Watchdog.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0' 
   s.osx.deployment_target = '10.9'
+  s.tvos.deployment_target = '9.0'
   s.requires_arc = true
 
   s.source_files = 'Classes/*.swift'


### PR DESCRIPTION
Simply adding tvOS to the Podspec for installation via Cocoapods.  Watchdog works great in tvOS.
