### PR TITLE
print -> NSLog

### DIFF
--- a/Classes/Watchdog.swift
+++ b/Classes/Watchdog.swift
@@ -24,7 +24,7 @@ import Foundation
             if strictMode {
                 assertionFailure()
             } else {
-                print(message)
+                NSLog("%@", message)
             }
         }
         


### PR DESCRIPTION
Using `NSLog`, though a bit ugly in Swift, has the advantage, that the diagnostic is logged in the system console — which is useful when we debug app extensions, Watch apps, or observe the behavior of a non-debug app (e.g. from TestFlight, not locally run)
