### PR TITLE
No functional change: expose an initializer that allows the client to have custom behavior when the watch dog fires.

### DIFF
--- a/Classes/Watchdog.swift
+++ b/Classes/Watchdog.swift
@@ -6,9 +6,10 @@ import Foundation
     private let pingThread: PingThread
 
     private static let defaultThreshold = 0.4
-    
-    /// @param threshold number of seconds that must pass to consider the main thread blocked.
-    /// @param strictMode boolean value that stops the execution whenever the threshold is reached.
+
+    /// Convenience initializer that allows you to construct a `WatchDog` object with default behavior.
+    /// - parameter threshold: number of seconds that must pass to consider the main thread blocked.
+    /// - parameter strictMode: boolean value that stops the execution whenever the threshold is reached.
     public convenience init(threshold: Double = Watchdog.defaultThreshold, strictMode: Bool = false) {
         self.init(threshold: threshold) {
             let message = "👮 Main thread was blocked for "
@@ -22,8 +23,9 @@ import Foundation
         }
     }
 
-    /// @param threshold number of seconds that must pass to consider the main thread blocked.
-    /// @param watchdogFiredCallback a callback that will be called when the the threshold is reached
+    /// Default initializer that allows you to construct a `WatchDog` object specifying a custom callback.
+    /// - parameter threshold: number of seconds that must pass to consider the main thread blocked.
+    /// - parameter watchdogFiredCallback: a callback that will be called when the the threshold is reached
     public init(threshold: Double = Watchdog.defaultThreshold, watchdogFiredCallback: () -> Void) {
         self.threshold = threshold
         self.pingThread = PingThread(threshold: threshold, handler: watchdogFiredCallback)

--- a/Classes/Watchdog.swift
+++ b/Classes/Watchdog.swift
@@ -1,48 +1,47 @@
 import Foundation
 
-@objc public class Watchdog: NSObject {
+/// Class for logging excessive blocking on the main thread.
+@objc final public class Watchdog: NSObject {
+    private let threshold: Double
+    private let pingThread: PingThread
+
+    private static let defaultThreshold = 0.4
     
-    private var threshold: Double
-    private var pingThread: PingThread
-    
-    /**
-     Class for logging excessive blocking on the main thread.
-     
-     @param threshold number of seconds that must pass to consider the main thread blocked.
-     
-     @param strictMode boolean value that stops the execution whenever the threshold is reached.
-     
-     */
-    public init(threshold: Double = 0.4, strictMode: Bool = false) {
-        
-        self.threshold = threshold
-        self.pingThread = PingThread(threshold: threshold) {
-            
+    /// @param threshold number of seconds that must pass to consider the main thread blocked.
+    /// @param strictMode boolean value that stops the execution whenever the threshold is reached.
+    public convenience init(threshold: Double = Watchdog.defaultThreshold, strictMode: Bool = false) {
+        self.init(threshold: threshold) {
             let message = "👮 Main thread was blocked for "
                 + String(format:"%.2f", threshold) + "s 👮"
-            
+
             if strictMode {
                 assertionFailure()
             } else {
                 NSLog("%@", message)
             }
         }
-        
+    }
+
+    /// @param threshold number of seconds that must pass to consider the main thread blocked.
+    /// @param watchdogFiredCallback a callback that will be called when the the threshold is reached
+    public init(threshold: Double = Watchdog.defaultThreshold, watchdogFiredCallback: () -> Void) {
+        self.threshold = threshold
+        self.pingThread = PingThread(threshold: threshold, handler: watchdogFiredCallback)
+
         self.pingThread.start()
         super.init()
     }
     
     deinit {
         pingThread.cancel()
-        
     }
 }
 
-private class PingThread: NSThread {
+private final class PingThread: NSThread {
     var pingTaskIsRunning = false
     var semaphore = dispatch_semaphore_create(0)
-    var threshold: Double
-    var handler: () -> Void
+    let threshold: Double
+    let handler: () -> Void
     
     init(threshold: Double, handler: () -> Void) {
         self.threshold = threshold
@@ -51,7 +50,6 @@ private class PingThread: NSThread {
     
     override func main() {
         while !self.cancelled {
-            
             pingTaskIsRunning = true
             dispatch_async(dispatch_get_main_queue()) {
                 self.pingTaskIsRunning = false


### PR DESCRIPTION
This is useful if an app wants to do something other than log with NSLog or call assertionFailure()

Other than that I made some nit-picky changes for correctness, like changing some vars for lets and using final.
