### PR TITLE
Setting iOS 8.0 as the deployment target

### DIFF
--- a/Watchdog.xcodeproj/project.pbxproj
+++ b/Watchdog.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Classes/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.wojtek.Watchdog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -284,6 +285,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Classes/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.wojtek.Watchdog;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
I'm using Watchdog with Carthage. The deploy target isn't explicitly set in the Watchdog project, so the resulting framework targets 8.4 up. This means I can't use Watchdog.framework with my project (which targets 8.0 up).
