### PR TITLE
Include the warning message in assertionFailure

### DIFF
--- a/Classes/Watchdog.swift
+++ b/Classes/Watchdog.swift
@@ -2,7 +2,6 @@ import Foundation
 
 /// Class for logging excessive blocking on the main thread.
 @objc final public class Watchdog: NSObject {
-    private let threshold: Double
     private let pingThread: PingThread
 
     private static let defaultThreshold = 0.4
@@ -27,7 +26,6 @@ import Foundation
     /// - parameter threshold: number of seconds that must pass to consider the main thread blocked.
     /// - parameter watchdogFiredCallback: a callback that will be called when the the threshold is reached
     public init(threshold: Double = Watchdog.defaultThreshold, watchdogFiredCallback: () -> Void) {
-        self.threshold = threshold
         self.pingThread = PingThread(threshold: threshold, handler: watchdogFiredCallback)
 
         self.pingThread.start()
@@ -40,10 +38,10 @@ import Foundation
 }
 
 private final class PingThread: NSThread {
-    var pingTaskIsRunning = false
-    var semaphore = dispatch_semaphore_create(0)
-    let threshold: Double
-    let handler: () -> Void
+    private var pingTaskIsRunning = false
+    private var semaphore = dispatch_semaphore_create(0)
+    private let threshold: Double
+    private let handler: () -> Void
     
     init(threshold: Double, handler: () -> Void) {
         self.threshold = threshold
@@ -51,7 +49,7 @@ private final class PingThread: NSThread {
     }
     
     override func main() {
-        while !self.cancelled {
+        while !cancelled {
             pingTaskIsRunning = true
             dispatch_async(dispatch_get_main_queue()) {
                 self.pingTaskIsRunning = false
@@ -60,7 +58,7 @@ private final class PingThread: NSThread {
             
             NSThread.sleepForTimeInterval(threshold)
             if pingTaskIsRunning {
-                self.handler()
+                handler()
             }
             
             dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)

--- a/Classes/Watchdog.swift
+++ b/Classes/Watchdog.swift
@@ -10,12 +10,11 @@ import Foundation
     /// - parameter threshold: number of seconds that must pass to consider the main thread blocked.
     /// - parameter strictMode: boolean value that stops the execution whenever the threshold is reached.
     public convenience init(threshold: Double = Watchdog.defaultThreshold, strictMode: Bool = false) {
-        self.init(threshold: threshold) {
-            let message = "👮 Main thread was blocked for "
-                + String(format:"%.2f", threshold) + "s 👮"
+        let message = "👮 Main thread was blocked for " + String(format:"%.2f", threshold) + "s 👮"
 
+        self.init(threshold: threshold) {
             if strictMode {
-                assertionFailure()
+                assertionFailure(message)
             } else {
                 NSLog("%@", message)
             }

--- a/Watchdog.xcodeproj/project.pbxproj
+++ b/Watchdog.xcodeproj/project.pbxproj
@@ -15,8 +15,6 @@
 		5C5A35B31BAC789D0057680B /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Classes/Info.plist; sourceTree = SOURCE_ROOT; };
 		5C5A35B41BAC789D0057680B /* Watchdog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Watchdog.h; path = Classes/Watchdog.h; sourceTree = SOURCE_ROOT; };
 		5CB520271BAC7807006C7C92 /* Watchdog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Watchdog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5CB520381BAC7807006C7C92 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		5CB520391BAC7807006C7C92 /* WatchdogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTests.swift; sourceTree = "<group>"; };
 		5CB520431BAC7844006C7C92 /* Watchdog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Watchdog.swift; path = Classes/Watchdog.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -35,7 +33,6 @@
 			isa = PBXGroup;
 			children = (
 				5CB520291BAC7807006C7C92 /* Watchdog */,
-				5CB520361BAC7807006C7C92 /* WatchdogTests */,
 				5CB520281BAC7807006C7C92 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -62,23 +59,6 @@
 			children = (
 				5C5A35B31BAC789D0057680B /* Info.plist */,
 				5C5A35B41BAC789D0057680B /* Watchdog.h */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		5CB520361BAC7807006C7C92 /* WatchdogTests */ = {
-			isa = PBXGroup;
-			children = (
-				5CB520391BAC7807006C7C92 /* WatchdogTests.swift */,
-				5CB520371BAC7807006C7C92 /* Supporting Files */,
-			);
-			path = WatchdogTests;
-			sourceTree = "<group>";
-		};
-		5CB520371BAC7807006C7C92 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				5CB520381BAC7807006C7C92 /* Info.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";


### PR DESCRIPTION
-  Adds the warning message to the assertionFailure when strictMode = false.
-  Removes unused `threshold` property.
-  Removes missing file references in the xcodeproj.
