### PR TITLE
Fixes data race for `pingTaskIsRunningLock`.

### DIFF
--- a/Classes/Watchdog.swift
+++ b/Classes/Watchdog.swift
@@ -37,7 +37,21 @@ import Foundation
 }
 
 private final class PingThread: Thread {
-    fileprivate var pingTaskIsRunning = false
+    fileprivate var pingTaskIsRunning: Bool {
+        get {
+            objc_sync_enter(pingTaskIsRunningLock)
+            let result = _pingTaskIsRunning;
+            objc_sync_exit(pingTaskIsRunningLock)
+            return result
+        }
+        set {
+            objc_sync_enter(pingTaskIsRunningLock)
+            _pingTaskIsRunning = newValue
+            objc_sync_exit(pingTaskIsRunningLock)
+        }
+    }
+    private var _pingTaskIsRunning = false
+    private let pingTaskIsRunningLock = NSObject()
     fileprivate var semaphore = DispatchSemaphore(value: 0)
     fileprivate let threshold: Double
     fileprivate let handler: () -> Void


### PR DESCRIPTION
First of all, great project! Thanks for creating this project.

When running the Example project *with Watchdog's  strict mode disabled*, the Xcode 8.2.1 ThreadSanitizer tool reports a data race (see below).

I think it might be more correct to protect reads and writes to `pingTaskIsRunning` with a lock, e.g. `objc_sync_enter`/`objc_sync_exit`.

ThreadSanitizer output with unmodified Watchdog code:
```
ThreadSanitizer debugger support is active.
2017-03-08 11:09:51.042 Example[28076:11260415] 👮 Main thread was blocked for 0.40s 👮
==================
WARNING: ThreadSanitizer: data race (pid=28076)
  Read of size 1 at 0x7d1c0000b800 by thread T7:
    #0 _TFC7ExampleP33_45325E8C26D30FB52B5DAE1418F9DBB210PingThread4mainfT_T_ Watchdog.swift:59 (Example+0x000100005524)
    #1 _TToFC7ExampleP33_45325E8C26D30FB52B5DAE1418F9DBB210PingThread4mainfT_T_ Watchdog.swift (Example+0x000100005803)
    #2 __NSThread__start__ <null>:170 (Foundation+0x000000031653)

  Previous write of size 1 at 0x7d1c0000b800 by main thread:
    #0 _TFFC7ExampleP33_45325E8C26D30FB52B5DAE1418F9DBB210PingThread4mainFT_T_U_FT_T_ Watchdog.swift:54 (Example+0x0001000056b5)
    #1 _TPA__TFFC7ExampleP33_45325E8C26D30FB52B5DAE1418F9DBB210PingThread4mainFT_T_U_FT_T_ Watchdog.swift (Example+0x0001000069be)
    #2 _TTRXFo___XFdCb___ Watchdog.swift (Example+0x000100005795)
    #3 __tsan::invoke_and_release_block(void*) <null>:224 (libclang_rt.tsan_iossim_dynamic.dylib+0x00000005c3fb)
    #4 _dispatch_client_callout <null>:159 (libdispatch.dylib+0x00000002c0cc)
    #5 start <null>:141 (libdyld.dylib+0x00000000468c)

  As if synchronized via sleep:
    #0 nanosleep <null>:224 (libclang_rt.tsan_iossim_dynamic.dylib+0x000000022143)
    #1 +[NSThread sleepForTimeInterval:] <null>:170 (Foundation+0x0000000cc65b)
    #2 _TToFC7ExampleP33_45325E8C26D30FB52B5DAE1418F9DBB210PingThread4mainfT_T_ Watchdog.swift (Example+0x000100005803)
    #3 __NSThread__start__ <null>:170 (Foundation+0x000000031653)

  Location is heap block of size 104 at 0x7d1c0000b7c0 allocated by main thread:
    #0 calloc <null>:224 (libclang_rt.tsan_iossim_dynamic.dylib+0x000000040672)
    #1 class_createInstance <null>:136 (libobjc.A.dylib+0x00000000f457)
    #2 _TFC7Example8WatchdogcfT9thresholdSd21watchdogFiredCallbackFT_T__S0_ Watchdog.swift:28 (Example+0x0001000045f1)
    #3 _TFC7Example8WatchdogcfT9thresholdSd10strictModeSb_S0_ Watchdog.swift:21 (Example+0x000100003f22)
    #4 _TFC7Example8WatchdogCfT9thresholdSd10strictModeSb_S0_ Watchdog.swift (Example+0x0001000040af)
    #5 _TFC7Example11AppDelegatecfT_S0_ AppDelegate.swift:15 (Example+0x0001000030ff)
    #6 _TToFC7Example11AppDelegatecfT_S0_ AppDelegate.swift (Example+0x000100003236)
    #7 _UIApplicationMainPreparations <null>:160 (UIKit+0x00000002835d)
    #8 start <null>:141 (libdyld.dylib+0x00000000468c)

  Thread T7 (tid=11260415, running) created by main thread at:
    #0 pthread_create <null>:224 (libclang_rt.tsan_iossim_dynamic.dylib+0x000000023b60)
    #1 -[NSThread start] <null>:170 (Foundation+0x000000031141)
    #2 _TFC7Example8WatchdogcfT9thresholdSd10strictModeSb_S0_ Watchdog.swift:21 (Example+0x000100003f22)
    #3 _TFC7Example8WatchdogCfT9thresholdSd10strictModeSb_S0_ Watchdog.swift (Example+0x0001000040af)
    #4 _TFC7Example11AppDelegatecfT_S0_ AppDelegate.swift:15 (Example+0x0001000030ff)
    #5 _TToFC7Example11AppDelegatecfT_S0_ AppDelegate.swift (Example+0x000100003236)
    #6 _UIApplicationMainPreparations <null>:160 (UIKit+0x00000002835d)
    #7 start <null>:141 (libdyld.dylib+0x00000000468c)

SUMMARY: ThreadSanitizer: data race Watchdog.swift:59 in _TFC7ExampleP33_45325E8C26D30FB52B5DAE1418F9DBB210PingThread4mainfT_T_
==================
ThreadSanitizer report breakpoint hit. Use 'thread info -s' to get extended information about the report.
```
