### PR TITLE
fix strict mode invalid for release build

### DIFF
--- a/Classes/Watchdog.swift
+++ b/Classes/Watchdog.swift
@@ -14,7 +14,7 @@ import Foundation
 
         self.init(threshold: threshold) {
             if strictMode {
-                assertionFailure(message)
+                fatalError(message)
             } else {
                 NSLog("%@", message)
             }


### PR DESCRIPTION
`assertionFailure` will invalid in default release config because of
`LLVM` 、`Swift Compiler` Optimization Level .